### PR TITLE
修复全局日志配置，启用DEBUG级别调试信息

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -237,10 +237,10 @@ async def get_current_user(
     
     try:
         token = credentials.credentials
-        logger.info(f"🔍 DEBUG: 开始验证令牌，令牌长度: {len(token) if token else 0}")
+        logger.debug(f"🔍 DEBUG: 开始验证令牌，令牌长度: {len(token) if token else 0}")
         
         user_id = get_user_id_from_token(token)
-        logger.info(f"🔍 DEBUG: 从令牌解析出用户ID: {user_id}")
+        logger.debug(f"🔍 DEBUG: 从令牌解析出用户ID: {user_id}")
         
         if user_id is None:
             logger.error("❌ DEBUG: 令牌解析失败，用户ID为None")
@@ -251,7 +251,7 @@ async def get_current_user(
             )
         
         user = db.query(User).filter(User.id == user_id).first()
-        logger.info(f"🔍 DEBUG: 数据库查询结果 - 用户: {user.email if user else 'None'}")
+        logger.debug(f"🔍 DEBUG: 数据库查询结果 - 用户: {user.email if user else 'None'}")
         
         if user is None:
             logger.error(f"❌ DEBUG: 用户ID {user_id} 在数据库中不存在")
@@ -270,7 +270,7 @@ async def get_current_user(
             )
         
         # 检查用户积分字段
-        logger.info(f"🔍 DEBUG: 用户积分信息 - credits: {user.credits}, type: {type(user.credits)}")
+        logger.debug(f"🔍 DEBUG: 用户积分信息 - credits: {user.credits}, type: {type(user.credits)}")
         
         # 如果积分为None，立即初始化
         if user.credits is None:
@@ -280,7 +280,7 @@ async def get_current_user(
             db.refresh(user)
             logger.info(f"✅ DEBUG: 积分初始化完成，当前积分: {user.credits}")
         
-        logger.info(f"✅ DEBUG: 用户认证成功 - ID: {user.id}, Email: {user.email}, Credits: {user.credits}")
+        logger.debug(f"✅ DEBUG: 用户认证成功 - ID: {user.id}, Email: {user.email}, Credits: {user.credits}")
         return user
         
     except HTTPException:

--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -46,8 +46,8 @@ async def upload_file(
     import logging
     logger = logging.getLogger(__name__)
     
-    logger.info(f"🔍 DEBUG: 开始处理文件上传 - 用户ID: {current_user.id}, 用户邮箱: {current_user.email}")
-    logger.info(f"🔍 DEBUG: 当前用户对象 - credits: {current_user.credits}, is_active: {current_user.is_active}")
+    logger.debug(f"🔍 DEBUG: 开始处理文件上传 - 用户ID: {current_user.id}, 用户邮箱: {current_user.email}")
+    logger.debug(f"🔍 DEBUG: 当前用户对象 - credits: {current_user.credits}, is_active: {current_user.is_active}")
     
     # 初始化积分服务
     credit_service = get_credit_service(db)
@@ -68,7 +68,7 @@ async def upload_file(
             detail=f"文件过大。最大支持 {settings.max_file_size // (1024*1024)} MB"
         )
     
-    logger.info(f"🔍 DEBUG: 文件验证通过 - 文件名: {file.filename}, 类型: {file_ext}, 大小: {len(file_content)} bytes")
+    logger.debug(f"🔍 DEBUG: 文件验证通过 - 文件名: {file.filename}, 类型: {file_ext}, 大小: {len(file_content)} bytes")
     
     # ========== 积分系统集成 ==========
     # 1. 估算所需积分
@@ -77,7 +77,7 @@ async def upload_file(
         file_type=file.content_type or file_ext
     )
     
-    logger.info(f"🔍 DEBUG: 积分估算完成 - 需要积分: {required_credits}")
+    logger.debug(f"🔍 DEBUG: 积分估算完成 - 需要积分: {required_credits}")
     
     # 2. 检查积分是否充足
     is_sufficient, current_balance = credit_service.check_sufficient_credits(
@@ -85,11 +85,11 @@ async def upload_file(
         required_credits=required_credits
     )
     
-    logger.info(f"🔍 DEBUG: 积分检查完成 - 充足: {is_sufficient}, 余额: {current_balance}")
+    logger.debug(f"🔍 DEBUG: 积分检查完成 - 充足: {is_sufficient}, 余额: {current_balance}")
     
     # 3. 如果不是管理员且积分不足，返回错误
     is_admin = credit_service.is_admin_user(current_user.id)
-    logger.info(f"🔍 DEBUG: 管理员检查 - 是否管理员: {is_admin}")
+    logger.debug(f"🔍 DEBUG: 管理员检查 - 是否管理员: {is_admin}")
     
     if not is_admin and not is_sufficient:
         error_detail = {

--- a/backend/app/services/credit_service.py
+++ b/backend/app/services/credit_service.py
@@ -31,14 +31,14 @@ class CreditService:
         import logging
         logger = logging.getLogger(__name__)
         
-        logger.info(f"🔍 DEBUG: 开始获取用户积分 - user_id: {user_id}")
+        logger.debug(f"🔍 DEBUG: 开始获取用户积分 - user_id: {user_id}")
         
         user = self.db.query(User).filter(User.id == user_id).first()
         if not user:
             logger.error(f"❌ DEBUG: 用户ID {user_id} 不存在")
             return 0
         
-        logger.info(f"🔍 DEBUG: 找到用户 - email: {user.email}, credits: {user.credits}, type: {type(user.credits)}")
+        logger.debug(f"🔍 DEBUG: 找到用户 - email: {user.email}, credits: {user.credits}, type: {type(user.credits)}")
         
         # 处理历史用户credits字段为NULL的情况
         if user.credits is None:
@@ -81,12 +81,12 @@ class CreditService:
         import logging
         logger = logging.getLogger(__name__)
         
-        logger.info(f"🔍 DEBUG: 检查积分充足性 - user_id: {user_id}, required: {required_credits}")
+        logger.debug(f"🔍 DEBUG: 检查积分充足性 - user_id: {user_id}, required: {required_credits}")
         
         current_credits = self.get_user_credits(user_id)
         is_sufficient = current_credits >= required_credits
         
-        logger.info(f"🔍 DEBUG: 积分检查结果 - current: {current_credits}, required: {required_credits}, sufficient: {is_sufficient}")
+        logger.debug(f"🔍 DEBUG: 积分检查结果 - current: {current_credits}, required: {required_credits}, sufficient: {is_sufficient}")
         
         return is_sufficient, current_credits
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,14 @@ ThinkSo FastAPI 主应用入口
 """
 
 import os
+import logging
+
+# 配置全局日志级别 - 支持调试信息
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -78,10 +86,7 @@ async def health_check():
 
 if __name__ == "__main__":
     import uvicorn
-    import logging
     
-    # 配置日志
-    logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
     
     try:


### PR DESCRIPTION
🐛 问题描述：
- Render部署后调试日志不显示
- Python logging模块日志级别配置不正确
- 无法在生产环境看到详细调试信息

🔧 修复内容：
1. 全局日志配置 (main.py):
   - 在应用启动前配置logging.basicConfig()
   - 设置日志级别为DEBUG
   - 添加统一的日志格式和时间戳
   - 移除重复的日志配置

2. 调试日志级别优化:
   - 将详细调试信息从logger.info()改为logger.debug()
   - 保留重要状态信息为INFO/WARNING级别
   - 确保错误信息仍为ERROR级别

3. 日志格式统一:
   - 时间戳格式: YYYY-MM-DD HH:MM:SS
   - 包含模块名称和日志级别
   - 便于生产环境问题排查

📋 现在可以看到的调试信息：
- Token解析过程详情
- 用户数据库查询结果
- 积分字段类型和值
- 积分检查计算过程
- 管理员权限验证

🎯 预期效果：
- 生产环境显示详细DEBUG日志
- 快速定位'undefined'积分问题
- 完整的请求处理流程追踪

🤖 Generated with [Claude Code](https://claude.ai/code)