### PR TITLE
fix: 修复依赖版本冲突导致的Render部署超时问题

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,8 +15,8 @@ PyMuPDF>=1.24.0
 
 # 认证和安全
 python-jose>=3.3.0
-passlib>=1.7.4
-bcrypt>=4.0.1
+passlib==1.7.4
+bcrypt==3.2.0
 PyJWT>=2.8.0  # JWT令牌处理
 slowapi>=0.1.9  # Rate limiting
 


### PR DESCRIPTION
- 固定 passlib 版本为 1.7.4，解决与 bcrypt 4.0+ 的兼容性问题
- 固定 bcrypt 版本为 3.2.0，确保稳定的密码哈希功能
- 避免 pip 在解析依赖时的版本冲突导致安装超时

🤖 Generated with [Claude Code](https://claude.ai/code)